### PR TITLE
Added strings.h to parser.c

### DIFF
--- a/parser.c
+++ b/parser.c
@@ -25,6 +25,7 @@
 /* vim: softtabstop=2 shiftwidth=2 expandtab  */
 #include <stdio.h>
 #include <string.h>
+#include <strings.h>
 #include <ctype.h>
 #include <stdlib.h>
 


### PR DESCRIPTION
Without it, I get:

```
warning: implicit declaration of function ‘bzero’ [-Wimplicit-function-declaration]
  130 |         bzero(token_space, MAX_TOKEN_LENGTH);
```