### PR TITLE
Makes the iterator the same type as num_cells

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -58,7 +58,7 @@ gc_init()
 {
   const unsigned  cell_size = sizeof(struct GCHeader) + sizeof(Object);
   unsigned char  *ptr;
-  int             i;
+  unsigned        i;
 
   num_cells = getenv("LISPKIT_MEMORY") ?
     atoi(getenv("LISPKIT_MEMORY")) : NUM_CELLS;


### PR DESCRIPTION
Fixes warning of comparison between types

```
 warning: comparison of integer expressions of different signedness: ‘int’ and ‘unsigned int’ [-Wsign-compare]
   74 |         for(i = 0, ptr = mem; i < num_cells; i++, ptr += cell_size) {
      |
```